### PR TITLE
website/metalcloud.erb: Fix sidebar names

### DIFF
--- a/website/metalcloud.erb
+++ b/website/metalcloud.erb
@@ -35,16 +35,16 @@
                   <a href="#">Instance array components</a>
                   <ul class="nav nav-visible">
                   <li>
-                    <a href="/docs/providers/metalcloud/r/instance_array_interface.html">interface</a>
+                    <a href="/docs/providers/metalcloud/r/instance_array_interface.html">instance_array_interface</a>
                   </li>
                   <li>
                     <a href="/docs/providers/metalcloud/r/firewall_rule.html">firewall_rule</a>
                   </li>
                   <li>
-                    <a href="/docs/providers/metalcloud/r/instance_custom_variables.html">interface</a>
+                    <a href="/docs/providers/metalcloud/r/instance_custom_variables.html">instance_custom_variables</a>
                   </li>
                   <li>
-                    <a href="/docs/providers/metalcloud/r/instance_array_custom_variables.html">interface</a>
+                    <a href="/docs/providers/metalcloud/r/instance_array_custom_variables.html">instance_array_custom_variables</a>
                   </li>
                   </ul>
             </li>


### PR DESCRIPTION
I don't know if you prefer to have the prefix of `metalcloud` on it or not as some do, but I based the names on the `firewall_rule` that does not have it.